### PR TITLE
Improve panel styling and download fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ docker run -d -p 3000:3000 \
 | `ADMIN_PASSWORD`  | `passwd` | 管理员口令，控制 **所有** 高权限操作（Bash、/bash、WebSocket 代理、进程终止）  |
 | `UPLOAD_PASSWORD` | `passwd` | 文件上传 / 新建 / 删除 时必填的口令                                |
 | `FILES_LIST_URL`  | *(URL)*  | 若 `DISABLE_ARUN` ≠ `1`，启动时从此 URL 下载文件列表并执行 `arun.sh` |
+| `FILES_LIST_URL_BACKUP` | *(URL)* | `FILES_LIST_URL` 无法访问时使用的备用链接 |
 | `DISABLE_ARUN`    | `1`      | 设为 `1` 可跳过自动下载与脚本执行（本地调试更安全）                         |
 
 ---
@@ -49,6 +50,8 @@ docker run -d -p 3000:3000 \
 ### 1. 综合面板 `/@`
 
 打开 `http://<host>:<port>/@` 可见双列 Dashboard：
+
+如需自定义界面样式，可在 `public/panel.css` 中编写 CSS，当该文件不存在时会使用内置默认样式。
 
 ![image](https://github.com/user-attachments/assets/dad0d6e4-2956-4aa0-a956-35797706cada)
 

--- a/public/panel.css
+++ b/public/panel.css
@@ -1,0 +1,37 @@
+body {
+  font-family: Consolas, monospace;
+  display: flex;
+  justify-content: space-between;
+  padding: 20px;
+  height: 100vh;
+  background: #2b2b2b;
+  color: #e0e0e0;
+}
+.panel {
+  width: 48%;
+  padding: 10px;
+  border: 1px solid #444;
+  border-radius: 5px;
+  background: #1e1e1e;
+  overflow: auto;
+}
+#output {
+  white-space: pre-wrap;
+  border: 1px solid #333;
+  padding: 10px;
+  margin-top: 20px;
+  max-height: 400px;
+  overflow-y: auto;
+  background: #000;
+  color: #0f0;
+}
+.cmd-entry {
+  margin-bottom: 10px;
+}
+.file-list ul {
+  list-style-type: none;
+  padding: 0;
+}
+.file-list li {
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- allow external CSS for `/@` panel
- add default dark style when no CSS file
- add retry and backup URL for downloading files
- document new `FILES_LIST_URL_BACKUP` env
- retry main URL again if backup fails

## Testing
- `node -c index.js`
- `DISABLE_ARUN=1 node index.js` *(manual start)*

------
https://chatgpt.com/codex/tasks/task_b_68482b52f46c832e89501b0833ecbfd8